### PR TITLE
Add missing nullptr check in instance finalization

### DIFF
--- a/src/api.cu
+++ b/src/api.cu
@@ -139,13 +139,15 @@ TRITONBACKEND_ModelInstanceFinalize(TRITONBACKEND_ModelInstance* instance)
     ModelInstanceState* instance_state =
         reinterpret_cast<ModelInstanceState*>(vstate);
 
-    instance_state->UnloadFILModel();
+    if (instance_state != nullptr) {
+      instance_state->UnloadFILModel();
 
-    LOG_MESSAGE(
-        TRITONSERVER_LOG_INFO,
-        "TRITONBACKEND_ModelInstanceFinalize: delete instance state");
+      LOG_MESSAGE(
+          TRITONSERVER_LOG_INFO,
+          "TRITONBACKEND_ModelInstanceFinalize: delete instance state");
 
-    delete instance_state;
+      delete instance_state;
+    }
   } catch (TritonException& err) {
     return err.error();
   }


### PR DESCRIPTION
Avoid bad calls to `fil::free` by ensuring that instance pointer is non-null before attempting `UnloadFilModel` call

Close #36 