### PR TITLE
Temporary fix for upstream cuML issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,6 @@ else()
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/src
       ${RAFT_DIR}
-      $ENV{CONDA_PREFIX}/include/cuml
   )
 
   target_compile_features(triton-fil-backend PRIVATE cxx_std_11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ else()
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/src
       ${RAFT_DIR}
+      $ENV{CONDA_PREFIX}/include/cuml
   )
 
   target_compile_features(triton-fil-backend PRIVATE cxx_std_11)
@@ -128,6 +129,7 @@ else()
     -Wall
     -Wextra
     -Wno-unused-parameter
+    -Wno-unused-variable
     -Wno-type-limits
     "$<$<COMPILE_LANGUAGE:CUDA>:-Werror=all-warnings>"
     "$<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Werror>"

--- a/qa/environment.yml
+++ b/qa/environment.yml
@@ -5,7 +5,7 @@ channels:
   - rapidsai-nightly
 dependencies:
   - cudatoolkit=11.0
-  - cuml=0.20
+  - cuml=21.06
   - lightgbm
   - pip
   - python=3.8


### PR DESCRIPTION
Include cuML header directory that is currently nested one layer too deep (to be fixed by https://github.com/rapidsai/cuml/pull/3901)

Ignore unused variable warnings due to unused variable in fil.h introduced by https://github.com/rapidsai/cuml/pull/3763