### PR TITLE
Use 1 as output dimension in testing non-proba classifiers

### DIFF
--- a/qa/L0_e2e/generate_example_model.py
+++ b/qa/L0_e2e/generate_example_model.py
@@ -209,7 +209,7 @@ def generate_config(
     if predict_proba:
         output_dim = num_classes
     else:
-        output_dim = 2  # TODO: Why not 1?
+        output_dim = 1
     predict_proba = str(bool(predict_proba)).lower()
     output_class = str(task == 'classification').lower()
 


### PR DESCRIPTION
Earlier use of 2 seems to have been required by a bug that has since been resolved and/or was the result of misinterpretation of earlier results. Update tests to use output dimension 1 as expected.

Resolve #47