### PR TITLE
Synchronize stream during TritonTensor sync

### DIFF
--- a/src/triton_fil/triton_tensor.cuh
+++ b/src/triton_fil/triton_tensor.cuh
@@ -184,6 +184,12 @@ class TritonTensor {
   {
     auto head = reinterpret_cast<typename std::conditional<
         std::is_const<T>::value, const std::byte*, std::byte*>::type>(buffer);
+    auto cuda_res = cudaStreamSynchronize(stream_);
+    if (cuda_res != cudaSuccess) {
+      throw TritonException(
+          TRITONSERVER_errorcode_enum::TRITONSERVER_ERROR_INTERNAL,
+          "Failed stream synchronization in TritonTensor sync");
+    }
     for (auto& out_buffer : final_buffers) {
       try {
         raft::copy(


### PR DESCRIPTION
Call `cudaStreamSynchronize` when syncing `TritonTensor` with output buffers in order to ensure correct output in cuda shared memory mode

Resolve #80