### PR TITLE
Remove guidance in docs on limit for large input arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,7 @@ specific to FIL:
   general, FIL's efficient handling of even large forest models means that this
   value can be quite high (2^13 in the example), but this may need to be
   reduced for your particular hardware configuration if you find that you are
-  exhausting system resources (such as GPU or system RAM). (NOTE: Due to a
-  [current bug](https://github.com/wphicks/triton_fil_backend/issues/40), this
-  value should not be set to 16384 or higher.
+  exhausting system resources (such as GPU or system RAM).
 - `input`: This configuration block specifies information about the input
   arrays that will be provided to the FIL model. The `dims` field should be set
   to `[ NUMBER_OF_FEATURES ]`, but all other fields should be left as they

--- a/qa/L0_e2e/generate_example_model.py
+++ b/qa/L0_e2e/generate_example_model.py
@@ -289,7 +289,8 @@ def generate_config(
         predict_proba=False,
         task='classification',
         threshold=0.5,
-        batching_window=30000):
+        batching_window=30000,
+        max_batch_size=8192):
     """Return a string with the full Triton config.pbtxt for this model
     """
     if predict_proba:
@@ -304,7 +305,7 @@ def generate_config(
 
     return f"""name: "{model_name}"
 backend: "fil"
-max_batch_size: 8192
+max_batch_size: {max_batch_size}
 input [
  {{
     name: "input__0"
@@ -370,7 +371,8 @@ def build_model(
         model_name=None,
         classification_threshold=0.5,
         predict_proba=False,
-        batching_window=30000):
+        batching_window=30000,
+        max_batch_size=8192):
     """Train a model with given parameters, create a config file, and add it to
     the model repository"""
 
@@ -437,7 +439,8 @@ def build_model(
         predict_proba=predict_proba,
         task=task,
         threshold=classification_threshold,
-        batching_window=batching_window
+        batching_window=batching_window,
+        max_batch_size=max_batch_size
     )
     config_path = os.path.join(config_dir, 'config.pbtxt')
 
@@ -525,6 +528,12 @@ def parse_args():
         help='window (in microseconds) for gathering batches',
         default=30000
     )
+    parser.add_argument(
+        '--max_batch_size',
+        type=int,
+        help='largest batch size allowed for this model',
+        default=8192
+    )
 
     return parser.parse_args()
 
@@ -545,5 +554,6 @@ if __name__ == '__main__':
         model_name=args.name,
         classification_threshold=args.threshold,
         predict_proba=args.predict_proba,
-        batching_window=args.batching_window
+        batching_window=args.batching_window,
+        max_batch_size=args.max_batch_size
     ))

--- a/qa/run_tests.sh
+++ b/qa/run_tests.sh
@@ -59,6 +59,7 @@ models+=( $(python ${test_dir}/generate_example_model.py \
   --type cuml \
   --depth 3 \
   --trees 10 \
+  --max_batch_size 32768 \
   --features 500 \
   --task regression) )
 "$script_dir/convert_cuml.py" "$test_dir/model_repository/cuml/1/model.pkl"
@@ -86,6 +87,9 @@ do
   if [ $i -eq 1 ]  # Test HTTP at most once because it is slower
   then
     python ${test_dir}/test_model.py --protocol http --name ${models[$i]}
+  elif [ ${models[$i]} = 'cuml' ]  # Test large inputs for just one model
+  then
+    python ${test_dir}/test_model.py --protocol grpc --name ${models[$i]} -b 32768
   else
     python ${test_dir}/test_model.py --protocol grpc --name ${models[$i]}
   fi


### PR DESCRIPTION
Remove docs reference to large input arrays, since current releases of Triton's Python client do not appear to have the observed limitations for input arrays over 2 MiB
Add test with input array over 2 MiB

Close #40