### PR TITLE
Skip cudaStreamSynchronize if no GPU is visible

### DIFF
--- a/qa/run_tests.sh
+++ b/qa/run_tests.sh
@@ -2,6 +2,7 @@
 set -e
 
 LOCAL=${LOCAL:-0}
+USE_GPU=${USE_GPU:-1}
 TRITON_IMAGE="${TRITON_IMAGE:-triton_fil}"
 if [ -z $SHOW_ENV ]
 then
@@ -47,31 +48,49 @@ fi
 models=()
 
 echo 'Generating example models...'
-models+=( $(python ${test_dir}/generate_example_model.py \
-  --name xgboost \
-  --depth 11 \
-  --trees 2000 \
-  --classes 3 \
-  --features 500) )
-models+=( $(python ${test_dir}/generate_example_model.py \
-  --name xgboost_json \
-  --format xgboost_json \
-  --depth 7 \
-  --trees 500 \
-  --features 500 \
-  --predict_proba) )
-models+=( $(python ${test_dir}/generate_example_model.py \
-  --name lightgbm \
-  --format lightgbm \
-  --type lightgbm \
-  --depth 3 \
-  --trees 2000) )
-models+=( $(python ${test_dir}/generate_example_model.py \
-  --name regression \
-  --depth 25 \
-  --features 400 \
-  --trees 10 \
-  --task regression) )
+if [ $USE_GPU -eq 1 ]
+then
+  models+=( $(python ${test_dir}/generate_example_model.py \
+    --name xgboost \
+    --depth 11 \
+    --trees 2000 \
+    --classes 3 \
+    --features 500) )
+  models+=( $(python ${test_dir}/generate_example_model.py \
+    --name xgboost_json \
+    --format xgboost_json \
+    --depth 7 \
+    --trees 500 \
+    --features 500 \
+    --predict_proba) )
+  models+=( $(python ${test_dir}/generate_example_model.py \
+    --name lightgbm \
+    --format lightgbm \
+    --type lightgbm \
+    --depth 3 \
+    --trees 2000) )
+  models+=( $(python ${test_dir}/generate_example_model.py \
+    --name regression \
+    --depth 25 \
+    --features 400 \
+    --trees 10 \
+    --task regression) )
+  models+=( $(python ${test_dir}/generate_example_model.py \
+    --name sklearn \
+    --type sklearn \
+    --depth 3 \
+    --trees 10 \
+    --features 500) )
+  "$script_dir/convert_sklearn" "$test_dir/model_repository/sklearn/1/model.pkl"
+  models+=( $(python ${test_dir}/generate_example_model.py \
+    --name cuml \
+    --type cuml \
+    --depth 3 \
+    --trees 10 \
+    --features 500 \
+    --task regression) )
+  "$script_dir/convert_cuml.py" "$test_dir/model_repository/cuml/1/model.pkl"
+fi
 
 models+=( $(python ${test_dir}/generate_example_model.py \
   --name xgboost-cpu \
@@ -103,26 +122,16 @@ models+=( $(python ${test_dir}/generate_example_model.py \
   --trees 10 \
   --task regression) )
 
-models+=( $(python ${test_dir}/generate_example_model.py \
-  --name sklearn \
-  --type sklearn \
-  --depth 3 \
-  --trees 10 \
-  --features 500) )
-"$script_dir/convert_sklearn" "$test_dir/model_repository/sklearn/1/model.pkl"
-models+=( $(python ${test_dir}/generate_example_model.py \
-  --name cuml \
-  --type cuml \
-  --depth 3 \
-  --trees 10 \
-  --features 500 \
-  --task regression) )
-"$script_dir/convert_cuml.py" "$test_dir/model_repository/cuml/1/model.pkl"
-
 echo 'Starting Triton server...'
 if [ $LOCAL -eq 1 ]
 then
-  container=$(docker run -d --gpus=all -p 8000:8000 -p 8001:8001 -p 8002:8002 -v $PWD/qa/L0_e2e/model_repository/:/models ${TRITON_IMAGE} tritonserver --model-repository=/models)
+  if [ $USE_GPU -eq 1 ]
+  then
+    DOCKER_FLAG='--gpus=all'
+  else
+    DOCKER_FLAG=''
+  fi
+  container=$(docker run -d $DOCKER_FLAG -p 8000:8000 -p 8001:8001 -p 8002:8002 -v $PWD/qa/L0_e2e/model_repository/:/models ${TRITON_IMAGE} tritonserver --model-repository=/models)
 
   function cleanup {
     docker logs $container > $log_dir/local_container.log 2>&1
@@ -135,15 +144,21 @@ else
 fi
 
 echo 'Testing example models...'
+if [ $USE_GPU -eq 1 ]
+then
+  SHARED_MEM_FLAG=''
+else
+  SHARED_MEM_FLAG='--shared_mem None'
+fi
 for i in ${!models[@]}
 do
   echo "Starting tests of model ${models[$i]}..."
   echo "Performance statistics for ${models[$i]}:"
   if [ $i -eq 1 ]  # Test HTTP at most once because it is slower
   then
-    python ${test_dir}/test_model.py --protocol http --name ${models[$i]}
+    python ${test_dir}/test_model.py --protocol http --name ${models[$i]} $SHARED_MEM_FLAG
   else
-    python ${test_dir}/test_model.py --protocol grpc --name ${models[$i]}
+    python ${test_dir}/test_model.py --protocol grpc --name ${models[$i]} $SHARED_MEM_FLAG
   fi
   echo "Model ${models[$i]} executed successfully"
 done

--- a/src/triton_fil/triton_tensor.cuh
+++ b/src/triton_fil/triton_tensor.cuh
@@ -213,11 +213,13 @@ class TritonTensor {
   {
     auto head = reinterpret_cast<typename std::conditional<
         std::is_const<T>::value, const std::byte*, std::byte*>::type>(buffer);
-    auto cuda_res = cudaStreamSynchronize(stream_);
-    if (cuda_res != cudaSuccess) {
-      throw TritonException(
-          TRITONSERVER_errorcode_enum::TRITONSERVER_ERROR_INTERNAL,
-          "Failed stream synchronization in TritonTensor sync");
+    if (target_memory_ == TRITONSERVER_MEMORY_GPU) {
+      auto cuda_res = cudaStreamSynchronize(stream_);
+      if (cuda_res != cudaSuccess) {
+        throw TritonException(
+            TRITONSERVER_errorcode_enum::TRITONSERVER_ERROR_INTERNAL,
+            "Failed stream synchronization in TritonTensor sync");
+      }
     }
     for (auto& out_buffer : final_buffers) {
       memory_copy(


### PR DESCRIPTION
Avoids the error `Thread [0] had error: Failed stream synchronization in TritonTensor sync` when running CPU inference with no visible GPU.