### PR TITLE
Eliminate system-specific path from quick_build

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -33,6 +33,8 @@ COPY ./ /triton_fil_backend
 
 WORKDIR /triton_fil_backend
 
+ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "triton_dev", "bash"]
+
 FROM base as build-stage
 
 ENV FIL_LIB=/opt/tritonserver/backends/fil/libtriton_fil.so

--- a/ops/quick_build.sh
+++ b/ops/quick_build.sh
@@ -16,7 +16,7 @@ docker run \
   -v "${REPO_ROOT}:/triton_fil_backend" \
   -v triton-ccache:/root/.ccache \
   -v triton-build:/triton_fil_backend/build \
-  -v /home/whicks/proj_cuml_triton/server/docs/examples/model_repository:/models \
+  -v "${REPO_ROOT}/qa/L0_e2e/model_repository:/models" \
   triton_dev
 
 popd > /dev/null 2>&1


### PR DESCRIPTION
Also add entrypoint to base stage of Dockerfile to make quick_build more easily usable.