### PR TITLE
Allow configurable grace period for server startup in tests

### DIFF
--- a/qa/L0_e2e/test_model.py
+++ b/qa/L0_e2e/test_model.py
@@ -366,16 +366,17 @@ def run_test(
         port=grpc_port
     )
 
-    # Wait up to 60 seconds for server startup
+    # Wait up to 180 seconds for server startup
+    server_startup = 180
     server_wait_start = time()
-    while time() - server_wait_start < 60:
+    while time() - server_wait_start < server_startup:
         try:
             if client.is_server_ready():
                 break
         except triton_utils.InferenceServerException:
             pass
-    if time() - server_wait_start > 60:
-        print("WARNING: Server may not be ready!")
+    if time() - server_wait_start > server_startup:
+        warnings.warn("Server may not be ready!")
 
     client.unregister_cuda_shared_memory()
     client.unregister_system_shared_memory()

--- a/qa/L0_e2e/test_model.py
+++ b/qa/L0_e2e/test_model.py
@@ -374,6 +374,8 @@ def run_test(
                 break
         except triton_utils.InferenceServerException:
             pass
+    if time() - server_wait_start > 60:
+        print("WARNING: Server may not be ready!")
 
     client.unregister_cuda_shared_memory()
     client.unregister_system_shared_memory()

--- a/qa/run_tests.sh
+++ b/qa/run_tests.sh
@@ -162,7 +162,7 @@ if [ $LOCAL -eq 1 ]
 then
   container=$(docker run -d --gpus=all -p 8000:8000 -p 8001:8001 -p 8002:8002 -v "$model_repo:/models" ${TRITON_IMAGE} tritonserver --model-repository=/models)
 else
-  tritonserver --model-repository="${model_repo}" &
+  tritonserver --model-repository="${model_repo}" > /logs/server.log 2>&1 &
   server_pid=$!
 fi
 

--- a/qa/run_tests.sh
+++ b/qa/run_tests.sh
@@ -166,8 +166,6 @@ else
   server_pid=$!
 fi
 
-sleep 60
-
 echo 'Testing GPU models...'
 for i in ${!models[@]}
 do
@@ -204,8 +202,6 @@ else
   tritonserver --model-repository="${cpu_model_repo}" > /logs/server.log 2>&1 &
   server_pid=$!
 fi
-
-sleep 60
 
 echo 'Testing CPU models...'
 for i in ${!cpu_models[@]}

--- a/qa/run_tests.sh
+++ b/qa/run_tests.sh
@@ -162,7 +162,7 @@ if [ $LOCAL -eq 1 ]
 then
   container=$(docker run -d --gpus=all -p 8000:8000 -p 8001:8001 -p 8002:8002 -v "$model_repo:/models" ${TRITON_IMAGE} tritonserver --model-repository=/models)
 else
-  tritonserver --model-repository="${model_repo}" > /logs/server.log 2>&1 &
+  tritonserver --model-repository="${model_repo}" &
   server_pid=$!
 fi
 

--- a/qa/run_tests.sh
+++ b/qa/run_tests.sh
@@ -166,6 +166,8 @@ else
   server_pid=$!
 fi
 
+sleep 60
+
 echo 'Testing GPU models...'
 for i in ${!models[@]}
 do
@@ -202,6 +204,8 @@ else
   tritonserver --model-repository="${cpu_model_repo}" > /logs/server.log 2>&1 &
   server_pid=$!
 fi
+
+sleep 60
 
 echo 'Testing CPU models...'
 for i in ${!cpu_models[@]}


### PR DESCRIPTION
Also default to a two minute grace period to accommodate move to different CI runners