### PR TITLE
Update to latest versions of Triton and RAPIDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/co
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
 if(TRITON_FIL_DOCKER_BUILD)
-  set(TRITON_BUILD_CONTAINER "nvcr.io/nvidia/tritonserver:21.11-py3" CACHE STRING "Build image for Dockerized builds")
-  set(TRITON_BUILD_CONTAINER_VERSION "21.11" CACHE STRING "Triton version for Dockerized builds")
+  set(TRITON_BUILD_CONTAINER "nvcr.io/nvidia/tritonserver:21.12-py3" CACHE STRING "Build image for Dockerized builds")
+  set(TRITON_BUILD_CONTAINER_VERSION "21.12" CACHE STRING "Triton version for Dockerized builds")
 
   add_custom_command(
     OUTPUT fil/libtriton_fil.so $<$<BOOL:${TRITON_ENABLE_GPU}>:fil/libcuml++.so>
@@ -67,7 +67,7 @@ else()
 
   ##############################################################################
   # - Prepare rapids-cmake -----------------------------------------------------
-  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.10/RAPIDS.cmake
+  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.12/RAPIDS.cmake
       ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
   include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
   include(rapids-cmake)
@@ -103,9 +103,9 @@ else()
 
   if(TRITON_ENABLE_GPU)
     rapids_cuda_init_architectures(RAPIDS_TRITON_BACKEND)
-    project(RAPIDS_TRITON_BACKEND VERSION 21.10.00 LANGUAGES CXX CUDA)
+    project(RAPIDS_TRITON_BACKEND VERSION 21.12.00 LANGUAGES CXX CUDA)
   else()
-    project(RAPIDS_TRITON_BACKEND VERSION 21.10.00 LANGUAGES CXX)
+    project(RAPIDS_TRITON_BACKEND VERSION 21.12.00 LANGUAGES CXX)
   endif()
 
   ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,10 +152,11 @@ else()
   # add third party dependencies using CPM
   rapids_cpm_init()
 
-  include(cmake/thirdparty/get_treelite.cmake)
   if(TRITON_ENABLE_GPU)
     include(cmake/thirdparty/get_raft.cmake)
     include(cmake/thirdparty/get_cuml.cmake)
+  else()
+    include(cmake/thirdparty/get_treelite.cmake)
   endif()
   include(cmake/thirdparty/get_rapids-triton.cmake)
 
@@ -208,8 +209,8 @@ else()
   if(TRITON_ENABLE_GPU)
     target_link_libraries(${BACKEND_TARGET}
     PRIVATE
-      $<IF:$<BOOL:${Treelite_ADDED}>,treelite::treelite_static,treelite::treelite>
-      $<IF:$<BOOL:${Treelite_ADDED}>,treelite::treelite_runtime_static,treelite::treelite_runtime>
+      treelite::treelite_static
+      treelite::treelite_runtime_static
       raft::raft
       cuml++
       rapids_triton::rapids_triton
@@ -221,8 +222,8 @@ else()
   else()
     target_link_libraries(${BACKEND_TARGET}
     PRIVATE
-      $<IF:$<BOOL:${Treelite_ADDED}>,treelite::treelite_static,treelite::treelite>
-      $<IF:$<BOOL:${Treelite_ADDED}>,treelite::treelite_runtime_static,treelite::treelite_runtime>
+      treelite::treelite_static
+      treelite::treelite_runtime_static
       rapids_triton::rapids_triton
       triton-core-serverstub
       triton-backend-utils

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,7 @@ script, which is used for building and testing individual configurations in CI.
 To run tests on a pre-built image, use the environment variable
 `PREBUILT_SERVER_TAG`:
 ```bash
-PREBUILT_SERVER_TAG=nvcr.io/nvidia/tritonserver:21.11-py3 ./ci/gitlab/build.sh
+PREBUILT_SERVER_TAG=nvcr.io/nvidia/tritonserver:21.12-py3 ./ci/gitlab/build.sh
 ```
 This will build a test image based on this pre-built server image and run it.
 For CPU-only builds, the environment variable `CPU_ONLY` should be set to 1.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pipelines.
 Pre-built Triton containers are available from NGC and may be pulled down via
 
 ```bash
-docker pull nvcr.io/nvidia/tritonserver:21.11-py3
+docker pull nvcr.io/nvidia/tritonserver:21.12-py3
 ```
 
 Note that the FIL backend cannot be used in the `21.06` version of this

--- a/cmake/thirdparty/get_cuml.cmake
+++ b/cmake/thirdparty/get_cuml.cmake
@@ -37,7 +37,7 @@ endfunction()
 # Change pinned tag here to test a commit in CI
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
-find_and_configure_cuml(VERSION    21.10
+find_and_configure_cuml(VERSION    21.12
                         FORK       rapidsai
-                        PINNED_TAG hotfix-21.10-pr-4315
+                        PINNED_TAG branch-21.12
                         )

--- a/conda/environments/triton_test.yml
+++ b/conda/environments/triton_test.yml
@@ -7,7 +7,7 @@ dependencies:
   - aws-sdk-cpp<1.9
   - clang-tools=11.1.0
   - cudatoolkit=11.4
-  - cuml=21.10
+  - cuml=21.12
   - flake8
   - hypothesis
   - lightgbm

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -2,7 +2,7 @@
 # Arguments for controlling build details
 ###########################################################################################
 # Version of Triton to use
-ARG TRITON_VERSION=21.11
+ARG TRITON_VERSION=21.12
 # Base container image
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 # Whether or not to enable GPU build

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -4,8 +4,8 @@ channels:
   - nvidia
   - rapidsai
 dependencies:
-  - cudatoolkit=11.0
-  - cuml=21.10
+  - cudatoolkit=11.4
+  - cuml=21.12
   - python=3.8
   - scikit-learn
   - treelite>=1.3.0


### PR DESCRIPTION
Update to RAPIDS 21.12 and Triton 21.12.

Note that a change in RAPIDS-CMake caused an issue with how Treelite was being included in our CMake infrastructure. Because of this, this PR is not quite as simple as our usual version bump PRs. These changes appear to be sufficient for the 22.01 build, and the underlying issue can be revisited in 22.02.

Resolve #159