### PR TITLE
fix some errors in `notebooks/simple-xgboost/`

### DIFF
--- a/notebooks/simple-xgboost/simple_xgboost_example.ipynb
+++ b/notebooks/simple-xgboost/simple_xgboost_example.ipynb
@@ -161,8 +161,7 @@
    "outputs": [],
    "source": [
     "y_pred = model.predict(X_test)\n",
-    "predictions = [round(value) for value in y_pred]\n",
-    "accuracy = accuracy_score(y_test, predictions)\n",
+    "accuracy = accuracy_score(y_test, y_pred)\n",
     "print(\"Test Accuracy: {:.2f}\".format(accuracy * 100.0))"
    ]
   },
@@ -235,7 +234,7 @@
     " {\n",
     "    name: \"output__0\"\n",
     "    data_type: TYPE_FP32\n",
-    "    dims: [ 2 ]                          # Output 2 for binary classification model\n",
+    "    dims: [ 1 ]                          # Output 2 for binary classification model\n",
     "  }\n",
     "]\n",
     "instance_group [{ kind: KIND_GPU }]\n",
@@ -299,7 +298,7 @@
     " {\n",
     "    name: \"output__0\"\n",
     "    data_type: TYPE_FP32\n",
-    "    dims: [ 2 ]                          # Output 2 for binary classification model\n",
+    "    dims: [ 1 ]                          # Output 2 for binary classification model\n",
     "  }\n",
     "]\n",
     "instance_group [{ kind: KIND_GPU }]\n",
@@ -571,7 +570,7 @@
    "source": [
     "## Deploy model with best configuration\n",
     "\n",
-    "Now we can deploy the model with configuration that gives best throughput and latency numbers as evaluated by the model analyzer. In our case, model configuration `fil_i10` gives the best configuration. We can now copy this config.pbtxt to model directory and re-deploy Triton Inference Server  "
+    "Now we can deploy the model with configuration that gives best throughput and latency numbers as evaluated by the model analyzer. In our case, model configuration `fil_config0` gives the best configuration. We can now copy this config.pbtxt to model directory and re-deploy Triton Inference Server  "
    ]
   },
   {
@@ -582,7 +581,7 @@
    "source": [
     "%%bash\n",
     "# Change the best model configuration as per required constraints\n",
-    "export best_model='fil_i0'\n",
+    "export best_model='fil_config0'\n",
     "cp -r output_model_repository/$best_model/ /model_repository/\n",
     "mkdir -p /model_repository/$best_model/1 && cp /model_repository/fil/1/xgboost.model /model_repository/$best_model/1/"
    ]
@@ -606,7 +605,7 @@
    "source": [
     "# Run the perf_analyzer with same parameters\n",
     "# Change the model as per your configuration \n",
-    "!perf_analyzer -m fil_i0 --percentile=99 --latency-threshold=5 --concurrency-range=10:15 --async -b 1"
+    "!perf_analyzer -m fil_config0 --percentile=99 --latency-threshold=5 --concurrency-range=10:15 --async -b 1"
    ]
   },
   {
@@ -687,8 +686,7 @@
     "result_http = request_http.as_numpy('output__0')\n",
     "\n",
     "# Check that we got the same accuracy as previously\n",
-    "predictions = [round(value) for value in result_http]\n",
-    "accuracy = accuracy_score(y_test, predictions)\n",
+    "accuracy = accuracy_score(y_test, result_http)\n",
     "print(\"Accuracy: {:.2f}\".format(accuracy * 100.0))"
    ]
   },


### PR DESCRIPTION
Changes made
- `fil_config0` instead of `fil_i0`
-  `output dim=1` instead of `2`

This is to resolve issue #166 

In some runs, the accuracy at the end doesn't match the accuracy in cell `6` without using triton. Need more experiments.