### PR TITLE
Use conda to avoid upstream mamba issue

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -39,7 +39,7 @@ RUN chmod +x /usr/bin/gpuci_conda_retry /usr/bin/gpuci_mamba_retry
 RUN --mount=type=cache,target=/root/miniconda3/pkgs gpuci_conda_retry install -c conda-forge mamba
 
 COPY ./conda/environments/rapids_triton_dev.yml /environment.yml
-RUN --mount=type=cache,target=/root/miniconda3/pkgs gpuci_mamba_retry env update -f /environment.yml \
+RUN --mount=type=cache,target=/root/miniconda3/pkgs gpuci_conda_retry env update -f /environment.yml \
     && rm /environment.yml
 
 RUN conda init && echo 'conda activate rapids_triton_dev' >> /root/.bashrc
@@ -129,7 +129,7 @@ FROM base as base-test-install
 
 COPY ./conda/environments/triton_test_no_client.yml /environment.yml
 
-RUN --mount=type=cache,target=/root/miniconda3/pkgs gpuci_mamba_retry env update -f /environment.yml \
+RUN --mount=type=cache,target=/root/miniconda3/pkgs gpuci_conda_retry env update -f /environment.yml \
     && rm /environment.yml
 
 FROM base-test-install as wheel-install-0


### PR DESCRIPTION
Currently, mamba intermittently throws errors of the form `ERROR   Could
not write out repodata file '/root/miniconda3/pkgs/cache/b8ab3f21.json':
No such file or directory` during environment installation. Switching
back to conda appears to resolve this.