### PR TITLE
Wait for background processes to exit in run_tests.sh

### DIFF
--- a/qa/run_tests.sh
+++ b/qa/run_tests.sh
@@ -91,6 +91,7 @@ finally() {
       docker rm -f $CONTAINER_NAME > /dev/null 2>&1
     else
       kill -15 $TRITON_PID
+      wait
     fi
   fi
 }


### PR DESCRIPTION
Ensure that tritonserver has successfully exited before proceeding to next round of tests