### PR TITLE
Do not use cache to avoid lock overlap with conda

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -36,10 +36,10 @@ COPY ./ops/gpuci_conda_retry /usr/bin/gpuci_conda_retry
 COPY ./ops/gpuci_mamba_retry /usr/bin/gpuci_mamba_retry
 RUN chmod +x /usr/bin/gpuci_conda_retry /usr/bin/gpuci_mamba_retry
 
-RUN --mount=type=cache,target=/root/miniconda3/pkgs gpuci_conda_retry install -c conda-forge mamba>=0.22
+RUN gpuci_conda_retry install -c conda-forge mamba>=0.22
 
 COPY ./conda/environments/rapids_triton_dev.yml /environment.yml
-RUN --mount=type=cache,target=/root/miniconda3/pkgs gpuci_mamba_retry env update -f /environment.yml \
+RUN gpuci_mamba_retry env update -f /environment.yml \
     && rm /environment.yml
 
 RUN conda init && echo 'conda activate rapids_triton_dev' >> /root/.bashrc
@@ -129,7 +129,7 @@ FROM base as base-test-install
 
 COPY ./conda/environments/triton_test_no_client.yml /environment.yml
 
-RUN --mount=type=cache,target=/root/miniconda3/pkgs gpuci_mamba_retry env update -f /environment.yml \
+RUN gpuci_mamba_retry env update -f /environment.yml \
     && rm /environment.yml
 
 FROM base-test-install as wheel-install-0


### PR DESCRIPTION
Currently, BuildKit parallelism causes conda installs to overlap from different layers, intermittently preventing one conda process from getting a lock. This PR eliminates the shared cache between layers. The performance impact of this is minimal and offset by the new use of mamba for environment installs.