### PR TITLE
Use conda-pack to simplify Dockerfile

### DIFF
--- a/ci/gitlab/build.sh
+++ b/ci/gitlab/build.sh
@@ -110,7 +110,7 @@ docker run \
   -v "${MODEL_DIR}:/qa/L0_e2e/model_repository" \
   -v "${CPU_MODEL_DIR}:/qa/L0_e2e/cpu_model_repository" \
   $MODEL_BUILDER_IMAGE \
-  bash -c 'conda run -n triton_test /qa/generate_example_models.sh'
+  bash -c 'source /conda/test/bin/activate && /qa/generate_example_models.sh'
 
 if [ $CPU_ONLY -eq 1 ]
 then

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -47,7 +47,7 @@ docker run \
   -v "${MODEL_DIR}:/qa/L0_e2e/model_repository" \
   -v "${CPU_MODEL_DIR}:/qa/L0_e2e/cpu_model_repository" \
   --rm $TEST_TAG \
-  bash -c 'conda run -n triton_test /qa/generate_example_models.sh'
+  bash -c 'source /conda/test/bin/activate && /qa/generate_example_models.sh'
 
 echo "Running GPU-enabled tests..."
 docker run \

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -130,6 +130,8 @@ ENV TRITON_FIL_ENABLE_TREESHAP=$TRITON_FIL_ENABLE_TREESHAP
 
 COPY --from=conda-dev /conda/dev /conda/dev
 
+SHELL ["/bin/bash", "-c"]
+
 RUN source /conda/dev/bin/activate \
  && cmake \
       --log-level=VERBOSE \

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -21,7 +21,7 @@ COPY ./ops/gpuci_mamba_retry /usr/bin/gpuci_mamba_retry
 RUN chmod +x /usr/bin/gpuci_conda_retry /usr/bin/gpuci_mamba_retry
 
 RUN mkdir /conda
-RUN gpuci_mamba_retry install -c conda-forge conda-pack
+RUN gpuci_mamba_retry install -c conda-forge conda-pack=0.7
 
 FROM conda-base as conda-dev
 COPY ./conda/environments/rapids_triton_dev.yml /conda/environment.yml

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -130,7 +130,7 @@ ENV TRITON_FIL_ENABLE_TREESHAP=$TRITON_FIL_ENABLE_TREESHAP
 
 COPY --from=conda-dev /conda/dev /conda/dev
 
-RUN . /conda/dev/bin/activate \
+RUN source /conda/dev/bin/activate \
  && cmake \
       --log-level=VERBOSE \
       -GNinja \
@@ -149,7 +149,7 @@ RUN . /conda/dev/bin/activate \
 
 ENV CCACHE_DIR=/ccache
 
-RUN --mount=type=cache,target=/ccache/ . /conda/dev/bin/activate && ninja install
+RUN --mount=type=cache,target=/ccache/ source /conda/dev/bin/activate && ninja install
 
 
 # Stage for generating testing image

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -15,38 +15,62 @@ ARG USE_CLIENT_WHEEL=0
 # SDK container image (only used if USE_CLIENT_WHEEL==1)
 ARG SDK_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3-sdk
 
+FROM condaforge/mambaforge as conda-base
+COPY ./ops/gpuci_conda_retry /usr/bin/gpuci_conda_retry
+COPY ./ops/gpuci_mamba_retry /usr/bin/gpuci_mamba_retry
+RUN chmod +x /usr/bin/gpuci_conda_retry /usr/bin/gpuci_mamba_retry
+
+RUN mkdir /conda
+RUN gpuci_mamba_retry install -c conda-forge conda-pack
+
+FROM conda-base as conda-dev
+COPY ./conda/environments/rapids_triton_dev.yml /conda/environment.yml
+RUN gpuci_mamba_retry env update -f /conda/environment.yml \
+ && rm /conda/environment.yml
+RUN conda-pack -n rapids_triton_dev -o /tmp/env.tar \
+ && mkdir /conda/dev/ \
+ && cd /conda/dev/ \
+ && tar xf /tmp/env.tar \
+ && rm /tmp/env.tar
+RUN /conda/dev/bin/conda-unpack
+
+# Stage for installing test dependencies
+FROM conda-base as base-test-install
+COPY ./conda/environments/triton_test_no_client.yml /environment.yml
+
+RUN gpuci_mamba_retry env update -f /environment.yml \
+    && rm /environment.yml
+
+FROM base-test-install as wheel-install-0
+RUN conda run --no-capture-output -n triton_test pip install tritonclient[all]
+
+FROM ${SDK_IMAGE} as sdk-image
+
+FROM base-test-install as wheel-install-1
+COPY --from=sdk-image /workspace/install/python /sdk_install
+RUN conda run --no-capture-output -n triton_test \
+    pip install /sdk_install/tritonclient*manylinux*.whl \
+ && rm -r /sdk_install
+
+FROM wheel-install-${USE_CLIENT_WHEEL} as conda-test
+RUN conda run --no-capture-output -n triton_test \
+    pip install git+https://github.com/rapidsai/rapids-triton.git@branch-21.12#subdirectory=python
+RUN conda-pack -n triton_test -o /tmp/env.tar \
+ && mkdir /conda/test/ \
+ && cd /conda/test/ \
+ && tar xf /tmp/env.tar \
+ && rm /tmp/env.tar
+RUN /conda/test/bin/conda-unpack
+
+
 FROM ${BASE_IMAGE} as base
 
 ENV PATH="/root/miniconda3/bin:${PATH}"
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y build-essential wget \
+    && apt-get install --no-install-recommends -y build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-ENV PYTHONDONTWRITEBYTECODE=true
-
-RUN wget \
-    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh \
-    && mkdir /root/.conda \
-    && bash Miniconda3-latest-Linux-$(uname -m).sh -b \
-    && rm -f Miniconda3-latest-Linux-$(uname -m).sh 
-
-COPY ./ops/gpuci_conda_retry /usr/bin/gpuci_conda_retry
-COPY ./ops/gpuci_mamba_retry /usr/bin/gpuci_mamba_retry
-RUN chmod +x /usr/bin/gpuci_conda_retry /usr/bin/gpuci_mamba_retry
-
-RUN gpuci_conda_retry install -c conda-forge mamba>=0.22
-
-COPY ./conda/environments/rapids_triton_dev.yml /environment.yml
-RUN gpuci_mamba_retry env update -f /environment.yml \
-    && rm /environment.yml
-
-RUN conda init && echo 'conda activate rapids_triton_dev' >> /root/.bashrc
-
-SHELL ["conda", "run", "--no-capture-output", "-n", "rapids_triton_dev", "/bin/bash", "-c"]
-
-ENV PYTHONDONTWRITEBYTECODE=false
 
 # Stage immediately before building; useful for build iteration
 FROM base as build-prep
@@ -104,75 +128,38 @@ ENV TRITON_FIL_USE_TREELITE_STATIC=$TRITON_FIL_USE_TREELITE_STATIC
 ARG TRITON_FIL_ENABLE_TREESHAP=ON
 ENV TRITON_FIL_ENABLE_TREESHAP=$TRITON_FIL_ENABLE_TREESHAP
 
-RUN cmake \
-    --log-level=VERBOSE \
-    -GNinja \
-    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-    -DBUILD_TESTS="${BUILD_TESTS}" \
-    -DTRITON_CORE_REPO_TAG="${TRITON_CORE_REPO_TAG}" \
-    -DTRITON_COMMON_REPO_TAG="${TRITON_COMMON_REPO_TAG}" \
-    -DTRITON_BACKEND_REPO_TAG="${TRITON_BACKEND_REPO_TAG}" \
-    -DTRITON_ENABLE_GPU="${TRITON_ENABLE_GPU}" \
-    -DTRITON_ENABLE_STATS="${TRITON_ENABLE_STATS}" \
-    -DRAPIDS_DEPENDENCIES_VERSION="${RAPIDS_DEPENDENCIES_VERSON}" \
-    -DTRITON_FIL_USE_TREELITE_STATIC="${TRITON_FIL_USE_TREELITE_STATIC}" \
-    -DTRITON_FIL_ENABLE_TREESHAP="${TRITON_FIL_ENABLE_TREESHAP}" \
-    -DCMAKE_INSTALL_PREFIX=/rapids_triton/install \
-    ..;
+COPY --from=conda-dev /conda/dev /conda/dev
+
+RUN source /conda/dev/bin/activate \
+ && cmake \
+      --log-level=VERBOSE \
+      -GNinja \
+      -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+      -DBUILD_TESTS="${BUILD_TESTS}" \
+      -DTRITON_CORE_REPO_TAG="${TRITON_CORE_REPO_TAG}" \
+      -DTRITON_COMMON_REPO_TAG="${TRITON_COMMON_REPO_TAG}" \
+      -DTRITON_BACKEND_REPO_TAG="${TRITON_BACKEND_REPO_TAG}" \
+      -DTRITON_ENABLE_GPU="${TRITON_ENABLE_GPU}" \
+      -DTRITON_ENABLE_STATS="${TRITON_ENABLE_STATS}" \
+      -DRAPIDS_DEPENDENCIES_VERSION="${RAPIDS_DEPENDENCIES_VERSON}" \
+      -DTRITON_FIL_USE_TREELITE_STATIC="${TRITON_FIL_USE_TREELITE_STATIC}" \
+      -DTRITON_FIL_ENABLE_TREESHAP="${TRITON_FIL_ENABLE_TREESHAP}" \
+      -DCMAKE_INSTALL_PREFIX=/rapids_triton/install \
+      ..;
 
 ENV CCACHE_DIR=/ccache
 
-RUN --mount=type=cache,target=/ccache/ ninja install
-
-# Stage for installing test dependencies
-FROM base as base-test-install
-
-COPY ./conda/environments/triton_test_no_client.yml /environment.yml
-
-RUN gpuci_mamba_retry env update -f /environment.yml \
-    && rm /environment.yml
-
-FROM base-test-install as wheel-install-0
-RUN conda run --no-capture-output -n triton_test pip install tritonclient[all]
-
-FROM ${SDK_IMAGE} as sdk-image
-
-FROM base-test-install as wheel-install-1
-COPY --from=sdk-image /workspace/install/python /sdk_install
-RUN conda run --no-capture-output -n triton_test \
-    pip install /sdk_install/tritonclient*manylinux*.whl \
- && rm -r /sdk_install
-
-FROM wheel-install-${USE_CLIENT_WHEEL} as test-install
-RUN conda run --no-capture-output -n triton_test \
-    pip install git+https://github.com/rapidsai/rapids-triton.git@branch-21.12#subdirectory=python
+RUN --mount=type=cache,target=/ccache/ source /conda/dev/bin/activate && ninja install
 
 
 # Stage for generating testing image
 FROM ${SERVER_IMAGE} as test-stage
-
-ENV PATH="/root/miniconda3/bin:${PATH}"
-ENV PYTHONDONTWRITEBYTECODE=true
-RUN if ! command -v conda; then \
-      wget \
-      https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh \
-      && mkdir /root/.conda \
-      && bash Miniconda3-latest-Linux-$(uname -m).sh -b \
-      && rm -f Miniconda3-latest-Linux-$(uname -m).sh \
-      && conda init; \
-    fi
-ENV PYTHONDONTWRITEBYTECODE=false
-
-COPY --from=test-install /root/miniconda3 /root/miniconda3
-
+COPY --from=conda-test /conda/test /conda/test
 COPY qa /qa
 COPY scripts /scripts
 
-# Default to triton_test conda env
-RUN sed -i s/rapids_triton_dev/triton_test/g /root/.bashrc
-
 ENTRYPOINT []
-CMD ["conda", "run", "--no-capture-output", "-n", "triton_test", "/qa/entrypoint.sh"]
+CMD ["source", "/conda/test/bin/activate", "&&", "/qa/entrypoint.sh"]
 
 FROM ${BASE_IMAGE} as final
 

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -159,7 +159,7 @@ COPY qa /qa
 COPY scripts /scripts
 
 ENTRYPOINT []
-CMD ["source", "/conda/test/bin/activate", "&&", "/qa/entrypoint.sh"]
+CMD ["/bin/bash", "-c", "source /conda/test/bin/activate && /qa/entrypoint.sh"]
 
 FROM ${BASE_IMAGE} as final
 

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -130,7 +130,7 @@ ENV TRITON_FIL_ENABLE_TREESHAP=$TRITON_FIL_ENABLE_TREESHAP
 
 COPY --from=conda-dev /conda/dev /conda/dev
 
-RUN source /conda/dev/bin/activate \
+RUN . /conda/dev/bin/activate \
  && cmake \
       --log-level=VERBOSE \
       -GNinja \
@@ -149,7 +149,7 @@ RUN source /conda/dev/bin/activate \
 
 ENV CCACHE_DIR=/ccache
 
-RUN --mount=type=cache,target=/ccache/ source /conda/dev/bin/activate && ninja install
+RUN --mount=type=cache,target=/ccache/ . /conda/dev/bin/activate && ninja install
 
 
 # Stage for generating testing image


### PR DESCRIPTION
Use conda-pack to move conda environments from dedicated conda installation layers to condaless layers where they will be used. Reduce unnecessary cache invalidation for conda installation layers. Resolve #215 .