### PR TITLE
Fix a comment in new CPU backend

### DIFF
--- a/src/herring/tl_helpers.hpp
+++ b/src/herring/tl_helpers.hpp
@@ -128,7 +128,7 @@ auto convert_tree(treelite::Tree<tl_threshold_t, tl_output_t> const& tl_tree, bo
       auto tl_split = tl_tree.SplitType(cur_node_id);
       auto categorical = (tl_split == treelite::SplitFeatureType::kCategorical);
 
-      // Hot child is always less-than or in-category condition
+      // Hot child is always greater-than or out-category condition
       if (!categorical) {
         cur_node.value.value = tl_tree.Threshold(cur_node_id);
         auto inclusive_threshold_node = (

--- a/src/herring/tl_helpers.hpp
+++ b/src/herring/tl_helpers.hpp
@@ -128,7 +128,7 @@ auto convert_tree(treelite::Tree<tl_threshold_t, tl_output_t> const& tl_tree, bo
       auto tl_split = tl_tree.SplitType(cur_node_id);
       auto categorical = (tl_split == treelite::SplitFeatureType::kCategorical);
 
-      // Hot child is always greater-than or out-category condition
+      // Distant child is always less-than or in-category condition
       if (!categorical) {
         cur_node.value.value = tl_tree.Threshold(cur_node_id);
         auto inclusive_threshold_node = (


### PR DESCRIPTION
According to the following snippet, the distant child is associated with the less-than condition.

https://github.com/triton-inference-server/fil_backend/blob/b0d46319dc65060e60ef0911d6ba67b439616a45/src/herring/node.hpp#L67-L81