### PR TITLE
Remove build-dir flag from build.py invocation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -285,7 +285,6 @@ buildpy () {
   pushd "${server_repo}"
   python3 build.py $BUILDPY_OPT \
     --cmake-dir=./build \
-    --build-dir=/tmp/citritonbuild \
     --enable-logging \
     --enable-metrics \
     --enable-stats \


### PR DESCRIPTION
Eliminate this flag in order to accommodate the change referenced in this comment:
https://github.com/triton-inference-server/server/commit/de061a41069bb6da665bf7a22ecd873d5939fd65#diff-b70bfb027a8ef3ec4ab07a53a3b8ba83e63334ba3ce5ca6d9d773900ed452e5eR2007-R2008