### PR TITLE
Remove unsupported build.py flag

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -284,7 +284,6 @@ buildpy () {
 
   pushd "${server_repo}"
   python3 build.py $BUILDPY_OPT \
-    --cmake-dir=./build \
     --enable-logging \
     --enable-metrics \
     --enable-stats \


### PR DESCRIPTION
--cmake-dir flag is now forbidden for Dockerized builds following an upstream Triton change