### PR TITLE
Merge key rotation hotfix back into main

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -69,6 +69,14 @@ FROM ${BASE_IMAGE} as base
 
 ENV PATH="/root/miniconda3/bin:${PATH}"
 
+RUN [ $(uname -m) = 'x86_64' ] \
+ && curl -o /tmp/cuda-keyring.deb \
+      https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb \
+ || curl -o /tmp/cuda-keyring.deb \
+      https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/sbsa/cuda-keyring_1.0-1_all.deb; \
+ dpkg -i /tmp/cuda-keyring.deb \
+ && rm /tmp/cuda-keyring.deb
+
 RUN apt-get update \
     && apt-get install --no-install-recommends -y build-essential \
     && apt-get clean \


### PR DESCRIPTION
* Update apt keys to allow apt updates

* Use curl since wget is unavailable on cpu build