### PR TITLE
Pin dependencies to avoid GLIBC version mismatch

### DIFF
--- a/conda/environments/rapids_triton_dev.yml
+++ b/conda/environments/rapids_triton_dev.yml
@@ -5,5 +5,7 @@ channels:
 dependencies:
   - ccache
   - cmake>=3.21,<3.23
+  - libstdcxx-ng<=11.2.0
+  - libgcc-ng<=11.2.0
   - ninja
   - rapidjson

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -3,7 +3,7 @@
 # Arguments for controlling build details
 ###########################################################################################
 # Version of Triton to use
-ARG TRITON_VERSION=22.03
+ARG TRITON_VERSION=22.04
 # Base container image
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 # Whether or not to enable GPU build


### PR DESCRIPTION
Without this fix, the server emits an error on model load like the following:
```
unable to load shared library: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.30' not found
```
This fix ensures that we are linking against a compatible version of libstdc++ to that used in the Triton server container.