### PR TITLE
Pin Hypothesis to avoid bug in FloatStrategy

### DIFF
--- a/conda/environments/triton_test.yml
+++ b/conda/environments/triton_test.yml
@@ -10,7 +10,7 @@ dependencies:
   - cudatoolkit=11.4
   - cuml=22.04
   - flake8
-  - hypothesis
+  - hypothesis<6.46.8
   - lightgbm
   - matplotlib
   - pip

--- a/conda/environments/triton_test_no_client.yml
+++ b/conda/environments/triton_test_no_client.yml
@@ -10,7 +10,7 @@ dependencies:
   - cudatoolkit=11.4
   - cuml=22.04
   - flake8
-  - hypothesis
+  - hypothesis<6.46.8
   - lightgbm
   - pip
   - pytest


### PR DESCRIPTION
Pin Hypothesis to <6.46.8 to avoid a bug introduced in this release
which prevents float draws being used in test_small. Without this pin,
Hypothesis fails to make the required draw, triggering a bad assert on
`assert smallest_nonzero_magnitude > 0.0` which in turn leads to an
unhandled AttributeError when trying to create a string representation
of the FloatStrategy object since it does not have a min_value
attribute.