### PR TITLE
Update docs to reflect XGBoost 1.6 JSON change

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,13 @@ binary format, XGBoost's JSON format, LightGBM's text format, and Treelite's
 binary checkpoint format. For those using cuML or Scikit-Learn random forest
 models, please see the [documentation on how to prepare such
 models](https://github.com/triton-inference-server/fil_backend/blob/main/SKLearn_and_cuML.md)
-for use in Triton. Once you have a serialized model, you will need to prepare a
+for use in Triton.
+
+**NOTE: XGBoost 1.6 introduced a change in the XGBoost JSON serialization
+format. This change will be supported in Triton 22.07. Earlier versions of
+Triton will NOT support JSON-serialized models from XGBoost>=1.6.**
+
+Once you have a serialized model, you will need to prepare a
 directory structure similar to the following example, which uses an XGBoost
 binary file:
 
@@ -467,9 +473,7 @@ configuration.
 
 This mode is still considered experimental in release 22.04, so it must be
 explicitly turned on by setting `use_experimental_optimizations` to `true` in
-the model's `config.pbtxt`. Currently, this mode does not support models with
-categorical features, but the FIL backend will automatically fall back to the
-older CPU execution mode for such models.
+the model's `config.pbtxt`.
 
 ## Modifications and Code Contributions
 For full implementation details as well as information on modifying the FIL

--- a/notebooks/categorical-fraud-detection/Fraud_Detection_Example.ipynb
+++ b/notebooks/categorical-fraud-detection/Fraud_Detection_Example.ipynb
@@ -34,8 +34,11 @@
     "  - scikit-learn\n",
     "  - pip:\n",
     "      - tritonclient[all]\n",
-    "      - xgboost>=1.5\n",
-    "```"
+    "      - xgboost>=1.5,<1.6\n",
+    "```\n",
+    "\n",
+    "### XGBoost 1.6\n",
+    "Note that due to a change in XGBoost's JSON serialization format, Triton will not be able to load JSON-serialized models from XGBoost 1.6 until Triton version 22.07."
    ]
   },
   {

--- a/notebooks/categorical-fraud-detection/environment.yml
+++ b/notebooks/categorical-fraud-detection/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - scikit-learn
   - pip:
       - tritonclient[all]
-      - xgboost>=1.5
+      - xgboost>=1.5,<1.6


### PR DESCRIPTION
Update docs and notebook to note that XGBoost 1.6 JSON change will not be supported until Triton 22.07. Also remove an out of date section describing experimental CPU optimizations.