### PR TITLE
Handle generic exception from Treelite

### DIFF
--- a/src/tl_utils.h
+++ b/src/tl_utils.h
@@ -65,6 +65,10 @@ inline auto load_tl_base_model(
     }
   } catch (treelite::Error const& err) {
     throw rapids::TritonException(rapids::Error::Unknown, err.what());
+  } catch (std::runtime_error const& err) {
+    // This block is needed because Treelite sometimes throws a generic exception
+    // TODO(hcho3): Revise Treelite so that it only throws treelite::Error
+    throw rapids::TritonException(rapids::Error::Unknown, err.what());
   }
 
   return result;


### PR DESCRIPTION
Closes #265

I submitted https://github.com/dmlc/treelite/pull/389 to avoid using generic exceptions like `std::runtime_error`. Since it takes a while for changes in Treelite to propagate to a Triton-FIL release, I am submitting this PR as an interim measure.