### PR TITLE
Fix Docker build target for test conda env

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -403,7 +403,7 @@ if [ $CONDA_TEST -eq 1 ]
 then
   docker build \
     $DOCKER_ARGS \
-    --target conda-test \
+    --target base-test-install \
     -t "$CONDA_TEST_TAG" \
     -f ops/Dockerfile \
     $REPODIR


### PR DESCRIPTION
Follow-up to #280 

The Conda env for testing is created in the `base-test-install` layer, not `conda-test`.