### PR TITLE
Pin cuML to version with pinned RAFT

### DIFF
--- a/cmake/thirdparty/get_cuml.cmake
+++ b/cmake/thirdparty/get_cuml.cmake
@@ -58,7 +58,7 @@ endfunction()
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_cuml(VERSION    ${RAPIDS_TRITON_MIN_VERSION_rapids_projects}
-                        FORK       rapidsai
-                        PINNED_TAG 80621f0b3718f565ece410ee3f71f36a8f44f5aa
+                        FORK       wphicks
+                        PINNED_TAG 37cbb48f51f1839bf04affd36dc0f4a441e6390f
                         USE_TREELITE_STATIC ${TRITON_FIL_USE_TREELITE_STATIC}
                         )


### PR DESCRIPTION
Unstable cuML pinned commit did not have a pinned RAFT version. Pin to a cuML commit with pinned RAFT.