### PR TITLE
[CI] Use Triton 22.12 in base container

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -3,7 +3,7 @@
 # Arguments for controlling build details
 ###########################################################################################
 # Version of Triton to use
-ARG TRITON_VERSION=22.11
+ARG TRITON_VERSION=22.12
 # Base container image
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 # Whether or not to enable GPU build


### PR DESCRIPTION
Triton released version 22.12 on Dec 20: https://github.com/triton-inference-server/server/releases/tag/v2.29.0

Part of #320