### PR TITLE
Bump Triton version number, Part 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/co
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 
 if(TRITON_FIL_DOCKER_BUILD)
-  set(TRITON_BUILD_CONTAINER "nvcr.io/nvidia/tritonserver:22.11-py3" CACHE STRING "Build image for Dockerized builds")
-  set(TRITON_BUILD_CONTAINER_VERSION "22.11" CACHE STRING "Triton version for Dockerized builds")
+  set(TRITON_BUILD_CONTAINER "nvcr.io/nvidia/tritonserver:22.12-py3" CACHE STRING "Build image for Dockerized builds")
+  set(TRITON_BUILD_CONTAINER_VERSION "22.12" CACHE STRING "Triton version for Dockerized builds")
 
   add_custom_command(
     OUTPUT fil/libtriton_fil.so $<$<BOOL:${TRITON_ENABLE_GPU}>:fil/libcuml++.so>

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ dynamic_batching {}
 ```
 docker run -p 8000:8000 -p 8001:8001 --gpus all \
   -v ${PWD}/model_repository:/models \
-  nvcr.io/nvidia/tritonserver:22.11-py3 \
+  nvcr.io/nvidia/tritonserver:22.12-py3 \
   tritonserver --model-repository=/models
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -198,7 +198,7 @@ if [ -z $TRITON_VERSION ] && [ $HOST_BUILD -eq 1 ]
 then
   # Must use a version compatible with a released backend image in order to
   # test a host build, so default to latest release branch rather than main
-  TRITON_VERSION=22.11
+  TRITON_VERSION=22.12
 fi
 
 if [ ! -z $TRITON_VERSION ]


### PR DESCRIPTION
Follow up with #323.

Need to update other parts of the repo to use Triton 22.12, per #310