### PR TITLE
Provide 24.03 version bumps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ else()
   ##############################################################################
   # - Prepare rapids-cmake -----------------------------------------------------
   file(DOWNLOAD
-    https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.12/RAPIDS.cmake
+    https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-24.02/RAPIDS.cmake
       ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
   include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
   include(rapids-cmake)
@@ -220,11 +220,11 @@ else()
   )
 
   if(TRITON_FIL_USE_TREELITE_STATIC)
-    list(APPEND TREELITE_LIBS treelite::treelite_static treelite::treelite_runtime_static)
-    list(APPEND TREELITE_LIBS_NO_PREFIX treelite_static treelite_runtime_static)
+    list(APPEND TREELITE_LIBS treelite::treelite_static)
+    list(APPEND TREELITE_LIBS_NO_PREFIX treelite_static)
   else()
-    list(APPEND TREELITE_LIBS treelite::treelite treelite::treelite_runtime)
-    list(APPEND TREELITE_LIBS_NO_PREFIX treelite treelite_runtime)
+    list(APPEND TREELITE_LIBS treelite::treelite)
+    list(APPEND TREELITE_LIBS_NO_PREFIX treelite)
   endif()
 
   target_link_libraries(${BACKEND_TARGET}

--- a/cmake/thirdparty/get_cuml.cmake
+++ b/cmake/thirdparty/get_cuml.cmake
@@ -56,7 +56,7 @@ endfunction()
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
 find_and_configure_cuml(VERSION    ${RAPIDS_TRITON_MIN_VERSION_rapids_projects}
-                        FORK       hcho3
-                        PINNED_TAG 09defa5201003b1f2d7742be38ea21d7a2eaff40
+                        FORK       rapidsai
+                        PINNED_TAG branch-24.02
                         USE_TREELITE_STATIC ${TRITON_FIL_USE_TREELITE_STATIC}
                         )

--- a/cmake/thirdparty/get_treelite.cmake
+++ b/cmake/thirdparty/get_treelite.cmake
@@ -75,7 +75,7 @@ function(find_and_configure_treelite)
 
     # Tell cmake where it can find the generated treelite-config.cmake we wrote.
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
-    rapids_export_find_package_root(BUILD Treelite [=[${CMAKE_CURRENT_LIST_DIR}]=] cuml-exports)
+    rapids_export_find_package_root(BUILD Treelite [=[${CMAKE_CURRENT_LIST_DIR}]=] EXPORT_SET cuml-exports)
 endfunction()
 
 find_and_configure_treelite(VERSION     4.0.0

--- a/cmake/thirdparty/get_treelite.cmake
+++ b/cmake/thirdparty/get_treelite.cmake
@@ -22,9 +22,9 @@ function(find_and_configure_treelite)
 
     message(VERBOSE "CUML: In treelite func, static: ${PKG_BUILD_STATIC_LIBS}")
     if(NOT PKG_BUILD_STATIC_LIBS)
-        list(APPEND TREELITE_LIBS treelite::treelite treelite::treelite_runtime)
+        list(APPEND TREELITE_LIBS treelite::treelite)
     else()
-        list(APPEND TREELITE_LIBS treelite::treelite_static treelite::treelite_runtime_static)
+        list(APPEND TREELITE_LIBS treelite::treelite_static)
     endif()
 
     rapids_cpm_find(Treelite ${PKG_VERSION}
@@ -39,9 +39,9 @@ function(find_and_configure_treelite)
     )
 
 
-    list(APPEND TREELITE_LIBS_NO_PREFIX treelite treelite_runtime)
+    list(APPEND TREELITE_LIBS_NO_PREFIX treelite)
     if(Treelite_ADDED AND PKG_BUILD_STATIC_LIBS)
-        list(APPEND TREELITE_LIBS_NO_PREFIX treelite_static treelite_runtime_static)
+        list(APPEND TREELITE_LIBS_NO_PREFIX treelite_static)
     endif()
 
     set(Treelite_ADDED ${Treelite_ADDED} PARENT_SCOPE)
@@ -52,27 +52,15 @@ function(find_and_configure_treelite)
             target_include_directories(treelite
                 PUBLIC $<BUILD_INTERFACE:${Treelite_SOURCE_DIR}/include>
                        $<BUILD_INTERFACE:${Treelite_BINARY_DIR}/include>)
-            target_include_directories(treelite_runtime
-                PUBLIC $<BUILD_INTERFACE:${Treelite_SOURCE_DIR}/include>
-                       $<BUILD_INTERFACE:${Treelite_BINARY_DIR}/include>)
             if(NOT TARGET treelite::treelite)
                 add_library(treelite::treelite ALIAS treelite)
-            endif()
-            if(NOT TARGET treelite::treelite_runtime)
-                add_library(treelite::treelite_runtime ALIAS treelite_runtime)
             endif()
         else()
             target_include_directories(treelite_static
                 PUBLIC $<BUILD_INTERFACE:${Treelite_SOURCE_DIR}/include>
                        $<BUILD_INTERFACE:${Treelite_BINARY_DIR}/include>)
-            target_include_directories(treelite_runtime_static
-                PUBLIC $<BUILD_INTERFACE:${Treelite_SOURCE_DIR}/include>
-                       $<BUILD_INTERFACE:${Treelite_BINARY_DIR}/include>)
             if(NOT TARGET treelite::treelite_static)
                 add_library(treelite::treelite_static ALIAS treelite_static)
-            endif()
-            if(NOT TARGET treelite::treelite_runtime_static)
-                add_library(treelite::treelite_runtime_static ALIAS treelite_runtime_static)
             endif()
         endif()
 
@@ -90,6 +78,6 @@ function(find_and_configure_treelite)
     rapids_export_find_package_root(BUILD Treelite [=[${CMAKE_CURRENT_LIST_DIR}]=] cuml-exports)
 endfunction()
 
-find_and_configure_treelite(VERSION     3.9.1
-                        PINNED_TAG  346d92547295417676f499ce2dd4fff946b9042a
+find_and_configure_treelite(VERSION     4.0.0
+                        PINNED_TAG  e878556d29336d2242fd926beb659b9dec41be3a
                         BUILD_STATIC_LIBS ${TRITON_FIL_USE_TREELITE_STATIC})

--- a/docs/model_support.md
+++ b/docs/model_support.md
@@ -81,7 +81,8 @@ shown below:
 | 21.11-22.02    | 2.1.0                         | <1.6                              |
 | 22.03-22.06    | 2.3.0                         | <1.6                              |
 | 22.07          | 2.4.0                         | <1.7                              |
-| 22.08+         | 2.4.0; >=3.0.0,<4.0.0         | <1.7                              |
+| 22.08-24.02    | 2.4.0; >=3.0.0,<4.0.0         | <1.7                              |
+| 24.03+         | 3.9.0; >=4.0.0,<5.0.0         | 1.7+                              |
 
 ## Limitations
 The FIL backend currently does not support any multi-output regression models.

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -3,7 +3,7 @@
 # Arguments for controlling build details
 ###########################################################################################
 # Version of Triton to use
-ARG TRITON_VERSION=24.01
+ARG TRITON_VERSION=24.02
 # Base container image
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 # Whether or not to enable GPU build


### PR DESCRIPTION
Use Triton 24.02 and cuML 24.02.

Note. Treelite 4.0.0 is now supported. However, Treelite 4.0.0 doesn't fully support `HistGradientBoosting` estimators in scikit-learn due to a bug (https://github.com/dmlc/treelite/issues/544). The full support is provided by Treelite 4.1.1, which will be brought into the FIL backend in release 24.05.