### PR TITLE
Provide 24.04 version bumps

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -3,7 +3,7 @@
 # Arguments for controlling build details
 ###########################################################################################
 # Version of Triton to use
-ARG TRITON_VERSION=24.02
+ARG TRITON_VERSION=24.03
 # Base container image
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 # Whether or not to enable GPU build

--- a/qa/L0_e2e/generate_example_model.py
+++ b/qa/L0_e2e/generate_example_model.py
@@ -17,8 +17,6 @@ import os
 import pickle
 
 import cuml
-import pandas as pd
-import sklearn.datasets
 from cuml.ensemble import RandomForestClassifier as cuRFC
 from cuml.ensemble import RandomForestRegressor as cuRFR
 
@@ -40,16 +38,21 @@ except ImportError:
 def generate_classification_data(classes=2, rows=1000, cols=32, cat_cols=0):
     """Generate classification training set"""
 
-    data, labels = sklearn.datasets.make_classification(
-        n_samples=rows,
-        n_features=cols,
-        n_informative=cols // 3,
-        n_classes=classes,
-        random_state=0,
-    )
+    if cat_cols > 0:
+        output_type = "cudf"
+    else:
+        output_type = "numpy"
+
+    with cuml.using_output_type(output_type):
+        data, labels = cuml.datasets.make_classification(
+            n_samples=rows,
+            n_features=cols,
+            n_informative=cols // 3,
+            n_classes=classes,
+            random_state=0,
+        )
 
     if cat_cols > 0:
-        data, labels = pd.DataFrame(data), pd.DataFrame(labels)
         selected_cols = data.sample(n=min(cat_cols, cols), axis="columns")
         negatives = selected_cols < 0
         positives = selected_cols >= 0
@@ -57,6 +60,8 @@ def generate_classification_data(classes=2, rows=1000, cols=32, cat_cols=0):
         selected_cols[negatives] = "negative"
         selected_cols[positives] = "positive"
         data[selected_cols.columns] = selected_cols.astype("category")
+        data = data.to_pandas()
+        labels = labels.to_pandas()
     return data, labels
 
 


### PR DESCRIPTION
* Use Triton 24.03 and cuML 24.02.
* Undo hack introduced in the 24.02 version (workaround was only needed for older GPUs)