### PR TITLE
FIx build by pinning RapidJSON to 1.1.0 stable

### DIFF
--- a/conda/environments/rapids_triton_dev.yml
+++ b/conda/environments/rapids_triton_dev.yml
@@ -6,4 +6,4 @@ dependencies:
   - ccache
   - cmake>=3.26.4
   - ninja
-  - rapidjson
+  - rapidjson>=1.1.0,<1.1.0.post*


### PR DESCRIPTION
Recently, Conda-forge released a new version of RapidJSON, `1.1.0.post20240409`. While it was meant to be a cosmetic change on top of 1.1.0, it is affected by a bug in CMake build (https://github.com/conda-forge/rapidjson-feedstock/issues/8, https://github.com/Tencent/rapidjson/pull/2193).

Fix: Pin RapidJSON to stable 1.1.0 version.