### PR TITLE
Update to RAPIDS-Triton 24.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ else()
   ##############################################################################
   # - Prepare rapids-cmake -----------------------------------------------------
   file(DOWNLOAD
-    https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-24.04/RAPIDS.cmake
+    https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-24.10/RAPIDS.cmake
       ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
   include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
   include(rapids-cmake)
@@ -97,7 +97,7 @@ else()
   set(BACKEND_FOLDER "/opt/tritonserver/backends" CACHE STRING "Triton backend folder path")
   # Specify *minimum* version for all RAPIDS dependencies
   # Some RAPIDS deps may have later versions
-  set(RAPIDS_DEPENDENCIES_VERSION "24.04" CACHE STRING "RAPIDS projects dependencies version")
+  set(RAPIDS_DEPENDENCIES_VERSION "24.10" CACHE STRING "RAPIDS projects dependencies version")
   option(TRITON_FIL_USE_TREELITE_STATIC "Link Treelite statically in libtriton_fil.so and cuml++.so" ON)
 
 

--- a/conda/environments/triton_benchmark.yml
+++ b/conda/environments/triton_benchmark.yml
@@ -15,4 +15,4 @@ dependencies:
   - pip:
       - tritonclient[all]
       - protobuf
-      - git+https://github.com/rapidsai/rapids-triton.git@branch-24.04#subdirectory=python
+      - git+https://github.com/rapidsai/rapids-triton.git@branch-24.10#subdirectory=python

--- a/conda/environments/triton_test.yml
+++ b/conda/environments/triton_test.yml
@@ -22,4 +22,4 @@ dependencies:
   - pip:
       - tritonclient[all]
       - protobuf
-      - git+https://github.com/rapidsai/rapids-triton.git@branch-24.04#subdirectory=python
+      - git+https://github.com/rapidsai/rapids-triton.git@branch-24.10#subdirectory=python

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -63,7 +63,7 @@ RUN conda run --no-capture-output -n triton_test \
 
 FROM wheel-install-${USE_CLIENT_WHEEL} as conda-test
 RUN conda run --no-capture-output -n triton_test \
-    pip install git+https://github.com/rapidsai/rapids-triton.git@branch-24.04#subdirectory=python
+    pip install git+https://github.com/rapidsai/rapids-triton.git@branch-24.10#subdirectory=python
 RUN conda-pack --ignore-missing-files -n triton_test -o /tmp/env.tar \
  && mkdir /conda/test/ \
  && cd /conda/test/ \
@@ -150,7 +150,7 @@ ENV TRITON_ENABLE_GPU=$TRITON_ENABLE_GPU
 
 # Specify *minimum* version for all RAPIDS dependencies
 # Some RAPIDS deps may have later versions
-ARG RAPIDS_DEPENDENCIES_VERSION=24.04
+ARG RAPIDS_DEPENDENCIES_VERSION=24.10
 ENV RAPIDS_DEPENDENCIES_VERSION=$RAPIDS_DEPENDENCIES_VERSION
 
 ARG TRITON_FIL_USE_TREELITE_STATIC=ON


### PR DESCRIPTION
RAPIDS-Triton was not updated since 24.04 and includes a change allowing propagation of the TRITON_REPO_ORGANIZATION option. Update to  24.10, including latest RAPIDS-Triton changes.