### PR TITLE
Remove deprecated numpy.product usage

### DIFF
--- a/qa/L0_e2e/test_model.py
+++ b/qa/L0_e2e/test_model.py
@@ -225,7 +225,7 @@ def model_data(request, client, model_repo):
     config = client.get_model_config(name)
     input_shapes = {input_.name: list(input_.dims) for input_ in config.input}
     output_sizes = {
-        output.name: np.product(output.dims) * np.dtype("float32").itemsize
+        output.name: np.prod(output.dims) * np.dtype("float32").itemsize
         for output in config.output
     }
     max_batch_size = config.max_batch_size


### PR DESCRIPTION
Update numpy.product to numpy.prod for compatibility with version brought in by 24.11 version bumps