### PR TITLE
Add Python to build environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,9 @@ set(RAPIDS_TRITON_REPO_PATH "https://github.com/rapidsai/rapids-triton.git" CACH
 set(RAPIDS_TRITON_REPO_TAG "branch-${RAPIDS_DEPENDENCIES_VERSION}" CACHE STRING "Tag for rapidsai/rapids-triton repo")
 
 if(TRITON_FIL_DOCKER_BUILD)
-  project(RAPIDS_TRITON_BACKEND VERSION 22.10.00)
-  set(TRITON_BUILD_CONTAINER "nvcr.io/nvidia/tritonserver:23.09-py3" CACHE STRING "Build image for Dockerized builds")
-  set(TRITON_BUILD_CONTAINER_VERSION "23.09" CACHE STRING "Triton version for Dockerized builds")
+  project(RAPIDS_TRITON_BACKEND VERSION 24.11.00)
+  set(TRITON_BUILD_CONTAINER "nvcr.io/nvidia/tritonserver:24.10-py3" CACHE STRING "Build image for Dockerized builds")
+  set(TRITON_BUILD_CONTAINER_VERSION "24.10" CACHE STRING "Triton version for Dockerized builds")
 
   add_custom_command(
     OUTPUT fil/libtriton_fil.so $<$<BOOL:${TRITON_ENABLE_GPU}>:fil/libcuml++.so>

--- a/conda/environments/buildpy.yml
+++ b/conda/environments/buildpy.yml
@@ -5,3 +5,4 @@ channels:
 dependencies:
   - docker-py
   - python
+  - distro

--- a/conda/environments/rapids_triton_dev.yml
+++ b/conda/environments/rapids_triton_dev.yml
@@ -6,6 +6,7 @@ dependencies:
   - ccache
   - cmake>=3.26.4,!=3.30.0
   - ninja
+  - python
   # TODO(hcho3): Remove the pin when
   # https://github.com/triton-inference-server/common/pull/114 is merged
   - rapidjson>=1.1.0,<1.1.0.post*


### PR DESCRIPTION
Add Python to build environment to allow for build of latest cutlass version (required in RAPIDS 24.12).

The following changes were not required for build fixes but were discovered and corrected along the way:
- Update default versions if none are provided by build process or CI
- Add new dependency for Triton's build.py to environment