### PR TITLE
Provide 25.01 version bumps

### DIFF
--- a/cmake/thirdparty/get_cuml.cmake
+++ b/cmake/thirdparty/get_cuml.cmake
@@ -55,8 +55,8 @@ endfunction()
 # Change pinned tag here to test a commit in CI
 # To use a different RAFT locally, set the CMake variable
 # CPM_raft_SOURCE=/path/to/local/raft
-find_and_configure_cuml(VERSION    24.10
+find_and_configure_cuml(VERSION    24.12
                         FORK       rapidsai
-                        PINNED_TAG feature/fil-backend-r24.11
+                        PINNED_TAG feature/fil-backend-r25.01
                         USE_TREELITE_STATIC ${TRITON_FIL_USE_TREELITE_STATIC}
                         )

--- a/cmake/thirdparty/get_treelite.cmake
+++ b/cmake/thirdparty/get_treelite.cmake
@@ -78,6 +78,6 @@ function(find_and_configure_treelite)
     rapids_export_find_package_root(BUILD Treelite [=[${CMAKE_CURRENT_LIST_DIR}]=] EXPORT_SET cuml-exports)
 endfunction()
 
-find_and_configure_treelite(VERSION     4.4.0
-                        PINNED_TAG  da70beb846dc5bc235643684b1b6176585dd094a
+find_and_configure_treelite(VERSION     4.4.1
+                        PINNED_TAG  386bd0de99f5a66584c7e58221ee38ce606ad1ae
                         BUILD_STATIC_LIBS ${TRITON_FIL_USE_TREELITE_STATIC})

--- a/conda/environments/triton_benchmark.yml
+++ b/conda/environments/triton_benchmark.yml
@@ -5,7 +5,7 @@ channels:
   - rapidsai
 dependencies:
   - cuda-version=11.8
-  - cudf=24.10
+  - cudf=24.12
   - libcusolver
   - libcusparse
   - matplotlib

--- a/conda/environments/triton_test.yml
+++ b/conda/environments/triton_test.yml
@@ -7,8 +7,8 @@ dependencies:
   - aws-sdk-cpp
   - clang-tools=11.1.0
   - cuda-version=11.8
-  - cudf=24.10
-  - cuml=24.10
+  - cudf=24.12
+  - cuml=24.12
   - flake8
   - hypothesis
   - lightgbm

--- a/conda/environments/triton_test_no_client.yml
+++ b/conda/environments/triton_test_no_client.yml
@@ -7,8 +7,8 @@ dependencies:
   - aws-sdk-cpp
   - clang-tools=11.1.0
   - cuda-version=11.8
-  - cudf=24.10
-  - cuml=24.10
+  - cudf=24.12
+  - cuml=24.12
   - flake8
   - hypothesis
   - lightgbm

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -3,7 +3,7 @@
 # Arguments for controlling build details
 ###########################################################################################
 # Version of Triton to use
-ARG TRITON_VERSION=24.11
+ARG TRITON_VERSION=24.12
 # Base container image
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 # Whether or not to enable GPU build

--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -5,7 +5,7 @@ channels:
   - rapidsai
 dependencies:
   - cuda-version=11.8
-  - cuml=24.10
+  - cuml=24.12
   - python
   - scikit-learn>=1.5
   - treelite>=4.3


### PR DESCRIPTION
The latest stable version of cuML (`branch-24.12`) doesn't use Treelite 4.4.1, so use a custom branch of cuML instead (`feature/fil-backend-r25.01`).