### PR TITLE
Add a requirement to use cmake < 4.0 until RapidJSON is compatible with Cmake 4.0.

### DIFF
--- a/conda/environments/rapids_triton_dev.yml
+++ b/conda/environments/rapids_triton_dev.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - ccache
-  - cmake>=3.26.4,!=3.30.0
+  - cmake>=3.26.4,!=3.30.0,<4.0.0
   - ninja
   - python
   # TODO(hcho3): Remove the pin when

--- a/docs/model_support.md
+++ b/docs/model_support.md
@@ -50,7 +50,8 @@ format.
 ## Serialization Formats
 The FIL backend currently supports the following serialization formats:
 
-- XGBoost JSON (Version < 1.7)
+- XGBoost JSON
+- XGBoost UBJSON
 - XGBoost Binary
 - LightGBM Text
 - Treelite binary checkpoint
@@ -74,15 +75,16 @@ changes.
 The compatibility matrix for Treelite and XGBoost with the FIL backend is
 shown below:
 
-| Triton Version | Supported Treelite Version(s) | Supported XGBoost JSON Version(s) |
-| -------------- | ----------------------------- | --------------------------------- |
-| 21.08          | 1.3.0                         | <1.6                              |
-| 21.09-21.10    | 2.0.0                         | <1.6                              |
-| 21.11-22.02    | 2.1.0                         | <1.6                              |
-| 22.03-22.06    | 2.3.0                         | <1.6                              |
-| 22.07          | 2.4.0                         | <1.7                              |
-| 22.08-24.02    | 2.4.0; >=3.0.0,<4.0.0         | <1.7                              |
-| 24.03+         | 3.9.0; >=4.0.0,<5.0.0         | 1.7+                              |
+| Triton Version | Supported Treelite Version(s) | Supported XGBoost models               |
+| -------------- | ----------------------------- | -------------------------------------- |
+| 21.08          | 1.3.0                         | XGBoost JSON <1.6                      |
+| 21.09-21.10    | 2.0.0                         | XGBoost JSON <1.6                      |
+| 21.11-22.02    | 2.1.0                         | XGBoost JSON <1.6                      |
+| 22.03-22.06    | 2.3.0                         | XGBoost JSON <1.6                      |
+| 22.07          | 2.4.0                         | XGBoost JSON <1.7                      |
+| 22.08-24.02    | 2.4.0; >=3.0.0,<4.0.0         | XGBoost JSON <1.7                      |
+| 24.03+         | 3.9.0; >=4.0.0,<5.0.0         | XGBoost JSON 1.7+                      |
+| 24.10+         | 3.9.0; >=4.0.0,<5.0.0         | XGBoost JSON 1.7+, XGBoost UBJSON 2.1+ |
 
 ## Limitations
 The FIL backend currently does not support any multi-output regression models.


### PR DESCRIPTION
Currently, We are hitting the following build issue when building the fil backend after CMake's recent update to default installation to 4.0.

````
Compatibility with CMake < 3.5 has been removed from CMake.
````

This change adds a requirement for the CMAKE version installed in the build to be less than <4.0.0 so we can use cmake version 3.31.6 instead to unblock building Triton base container. 


Based on the changes, The output shows we are able to build the backend.
````
#32 DONE 656.8s

#33 [final 4/4] COPY --from=build-stage   /opt/tritonserver/backends/fil   /opt/tritonserver/backends/fil
#33 DONE 0.1s
````