### PR TITLE
Fix Mamba environment build

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -27,7 +27,8 @@ RUN gpuci_mamba_retry install -c conda-forge conda-pack=0.7
 
 FROM conda-base as conda-dev
 COPY ./conda/environments/rapids_triton_dev.yml /conda/environment.yml
-RUN gpuci_mamba_retry env update -f /conda/environment.yml \
+RUN gpuci_mamba_retry create -n rapids_triton_dev \
+ && gpuci_mamba_retry env update -n rapids_triton_dev -f /conda/environment.yml \
  && rm /conda/environment.yml
 RUN conda-pack -n rapids_triton_dev -o /tmp/env.tar \
  && mkdir /conda/dev/ \

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -41,7 +41,8 @@ RUN /conda/dev/bin/conda-unpack
 FROM conda-base as base-test-install
 COPY ./conda/environments/triton_test_no_client.yml /environment.yml
 
-RUN gpuci_mamba_retry env update -f /environment.yml \
+RUN gpuci_mamba_retry create -n triton_test \
+    && gpuci_mamba_retry env update -n triton_test -f /environment.yml \
     && rm /environment.yml
 
 FROM base-test-install as wheel-install-0


### PR DESCRIPTION
We need to specify the environment name explicitly to avoid the error like
```
#26 0.286 error    libmamba No prefix found at: /opt/conda/envs/rapids_triton_dev
#26 0.286 error    libmamba Environment must first be created with "mamba create -n {env_name} ..."
#26 0.286 critical libmamba Aborting.
```