### PR TITLE
build: Update C++ standard from c++17 to c++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,9 +198,9 @@ else()
     PROPERTIES BUILD_RPATH                         "\$ORIGIN"
                INSTALL_RPATH                       "\$ORIGIN"
                # set target compile options
-               CXX_STANDARD                        17
+               CXX_STANDARD                        20
                CXX_STANDARD_REQUIRED               ON
-               CUDA_STANDARD                       17
+               CUDA_STANDARD                       20
                CUDA_STANDARD_REQUIRED              ON
                POSITION_INDEPENDENT_CODE           ON
                INTERFACE_POSITION_INDEPENDENT_CODE ON
@@ -210,7 +210,7 @@ else()
     PROPERTIES BUILD_RPATH                         "\$ORIGIN"
                INSTALL_RPATH                       "\$ORIGIN"
                # set target compile options
-               CXX_STANDARD                        17
+               CXX_STANDARD                        20
                CXX_STANDARD_REQUIRED               ON
                POSITION_INDEPENDENT_CODE           ON
                INTERFACE_POSITION_INDEPENDENT_CODE ON

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,10 +67,10 @@ function(ConfigureTest)
   set_target_properties(
     ${_TRITON_FIL_TEST_NAME}
     PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib"
-               CXX_STANDARD 17
+               CXX_STANDARD 20
                CXX_STANDARD_REQUIRED ON)
   if(TRITON_ENABLE_GPU)
-    set_target_properties(${_TRITON_FIL_TEST_NAME} PROPERTIES CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON)
+    set_target_properties(${_TRITON_FIL_TEST_NAME} PROPERTIES CUDA_STANDARD 20 CUDA_STANDARD_REQUIRED ON)
   endif()
 
   set(_TRITON_FIL_TEST_COMPONENT_NAME testing)


### PR DESCRIPTION
#### What does the PR do?
- Upstream PyTorch raised ATen's minimum required C++ standard from 17 to 20 (pytorch/pytorch#178150), breaking the pytorch_backend build.
- Bumps this repo's C++ standard default from 17 to 20 for consistency across the Triton stack.


#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- triton-inference-server/pytorch_backend#210
- triton-inference-server/backend#129
- triton-inference-server/checksum_repository_agent#16
- triton-inference-server/identity_backend#38
- triton-inference-server/local_cache#18
- triton-inference-server/openvino_backend#123
- triton-inference-server/redis_cache#26
- triton-inference-server/repeat_backend#21
- triton-inference-server/square_backend#24
- triton-inference-server/tensorrt_backend#128
- triton-inference-server/third_party#82
- triton-inference-server/common#166
- triton-inference-server/core#525
- triton-inference-server/client#922
- triton-inference-server/onnxruntime_backend#359
- triton-inference-server/server#8962
- triton-inference-server/python_backend#455
- triton-inference-server/dali_backend#311

#### Where should the reviewer start?
- `CMakeLists.txt` - `test/CMakeLists.txt` 

#### Test plan:
- CI Pipeline ID: 67062220

#### Caveats:
This repo has no direct dependency on ATen/libtorch; the bump is for cross-repo C++ standard consistency, not a confirmed build break here.

#### Background
Part of a coordinated C++17->C++20 bump across ~18 Triton component repos (TRI-1877), triggered by upstream PyTorch's ATen.h now requiring C++20.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1877
