### PR TITLE
build: Update C++ standard from c++17 to c++20 (#461)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,9 +198,9 @@ else()
     PROPERTIES BUILD_RPATH                         "\$ORIGIN"
                INSTALL_RPATH                       "\$ORIGIN"
                # set target compile options
-               CXX_STANDARD                        17
+               CXX_STANDARD                        20
                CXX_STANDARD_REQUIRED               ON
-               CUDA_STANDARD                       17
+               CUDA_STANDARD                       20
                CUDA_STANDARD_REQUIRED              ON
                POSITION_INDEPENDENT_CODE           ON
                INTERFACE_POSITION_INDEPENDENT_CODE ON
@@ -210,7 +210,7 @@ else()
     PROPERTIES BUILD_RPATH                         "\$ORIGIN"
                INSTALL_RPATH                       "\$ORIGIN"
                # set target compile options
-               CXX_STANDARD                        17
+               CXX_STANDARD                        20
                CXX_STANDARD_REQUIRED               ON
                POSITION_INDEPENDENT_CODE           ON
                INTERFACE_POSITION_INDEPENDENT_CODE ON

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,10 +67,10 @@ function(ConfigureTest)
   set_target_properties(
     ${_TRITON_FIL_TEST_NAME}
     PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../lib"
-               CXX_STANDARD 17
+               CXX_STANDARD 20
                CXX_STANDARD_REQUIRED ON)
   if(TRITON_ENABLE_GPU)
-    set_target_properties(${_TRITON_FIL_TEST_NAME} PROPERTIES CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON)
+    set_target_properties(${_TRITON_FIL_TEST_NAME} PROPERTIES CUDA_STANDARD 20 CUDA_STANDARD_REQUIRED ON)
   endif()
 
   set(_TRITON_FIL_TEST_COMPONENT_NAME testing)


### PR DESCRIPTION
Upstream PyTorch raised ATen's minimum required C++ standard from 17 to 20 (pytorch/pytorch#178150), which broke the pytorch_backend build. Align this repo's CXX_STANDARD/CUDA_STANDARD default with that floor for consistency across the stack.

TRI-1877